### PR TITLE
Fix bad environment merge with explicit delete

### DIFF
--- a/overlay/delete_db_user_patch.yaml
+++ b/overlay/delete_db_user_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress-challenge
+spec:
+  template:
+    spec:
+      containers:
+        - name: wordpress
+          env:
+            - name: WORDPRESS_DB_USER
+              $patch: delete

--- a/overlay/kustomization.yaml
+++ b/overlay/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
 - better_login.yaml
 
 patchesStrategicMerge:
-- login_patch.yaml
-- db_login_patch.yaml
+  - db_login_patch.yaml
+  - delete_db_user_patch.yaml
+  - login_patch.yaml


### PR DESCRIPTION
This introduces as new patches that explicitly deletes the entry for
WORDPRESS_DB_USER, which is then re-added by the subsequent patch